### PR TITLE
fix: Improve search error handling and display failed searches properly

### DIFF
--- a/chemscreen/models.py
+++ b/chemscreen/models.py
@@ -111,6 +111,16 @@ class SearchResult(BaseModel):
     )
     from_cache: bool = Field(False, description="Whether results came from cache")
 
+    @property
+    def is_failed(self) -> bool:
+        """Check if this search result represents a failed search."""
+        return self.error is not None
+
+    @property
+    def is_successful(self) -> bool:
+        """Check if this search result represents a successful search."""
+        return self.error is None
+
     model_config = ConfigDict(validate_assignment=True)
 
 

--- a/chemscreen/pubmed.py
+++ b/chemscreen/pubmed.py
@@ -157,13 +157,43 @@ class PubMedClient:
                 from_cache=False,
             )
 
-        except Exception as e:
-            logger.error(f"Search failed for {chemical.name}: {str(e)}")
+        except aiohttp.ClientConnectionError as e:
+            logger.error(f"Connection error for {chemical.name}: {str(e)}")
             return SearchResult(
                 chemical=chemical,
                 total_count=0,
                 publications=[],
-                error=str(e),
+                error=f"Connection failed: {str(e)}",
+                search_time_seconds=asyncio.get_event_loop().time() - start_time,
+                from_cache=False,
+            )
+        except aiohttp.ClientTimeout as e:
+            logger.error(f"Timeout error for {chemical.name}: {str(e)}")
+            return SearchResult(
+                chemical=chemical,
+                total_count=0,
+                publications=[],
+                error=f"Request timeout: {str(e)}",
+                search_time_seconds=asyncio.get_event_loop().time() - start_time,
+                from_cache=False,
+            )
+        except aiohttp.ClientResponseError as e:
+            logger.error(f"HTTP error for {chemical.name}: {e.status} - {str(e)}")
+            return SearchResult(
+                chemical=chemical,
+                total_count=0,
+                publications=[],
+                error=f"HTTP error {e.status}: {str(e)}",
+                search_time_seconds=asyncio.get_event_loop().time() - start_time,
+                from_cache=False,
+            )
+        except Exception as e:
+            logger.error(f"Unexpected error for {chemical.name}: {str(e)}")
+            return SearchResult(
+                chemical=chemical,
+                total_count=0,
+                publications=[],
+                error=f"Search failed: {str(e)}",
                 search_time_seconds=asyncio.get_event_loop().time() - start_time,
                 from_cache=False,
             )


### PR DESCRIPTION
## Summary
- Fix SSL connection errors appearing as successful searches with 0 results
- Add proper error categorization and display for failed searches
- Enable users to download failed searches for retry

## Changes Made
- **Enhanced PubMedClient error handling**: Added specific exception handling for `ClientConnectionError`, `ClientTimeout`, and `ClientResponseError`
- **Improved SearchResult model**: Added `is_failed` and `is_successful` properties for cleaner error checking
- **Enhanced Results page UI**: 
  - Failed searches now clearly marked as "❌ Failed" 
  - Added "Error Details" column showing specific error messages
  - New "Failed Searches" section with detailed error information
  - CSV download button for failed searches to enable retry

## Problem Solved
Previously, when SSL connection errors occurred (like `[SSL: APPLICATION_DATA_AFTER_CLOSE_NOTIFY]`), searches would appear as "successful" with 0 results instead of being properly marked as failed. This was confusing for users who couldn't distinguish between legitimate 0 results vs connection failures.

## Test Plan
- [x] Test with network connection issues to verify proper error handling
- [x] Verify failed searches show as "❌ Failed" in results table
- [x] Test CSV download functionality for failed searches
- [x] Confirm error details are displayed properly in UI

## Related Issues
- Addresses connection error handling issues mentioned in user feedback
- Provides foundation for #34 (retry functionality)

🤖 Generated with [Claude Code](https://claude.ai/code)